### PR TITLE
Set language for Japanese terminology file to 'ja'

### DIFF
--- a/openEHR_RM/ja/openehr_terminology.xml
+++ b/openEHR_RM/ja/openehr_terminology.xml
@@ -1,4 +1,4 @@
-<terminology name="openehr" language="en">	
+<terminology name="openehr" language="ja">	
 	<codeset issuer="openehr" openehr_id="compression algorithms" external_id="openehr_compression_algorithms">
 		<code value="圧縮"/>
 		<code value="展開"/>


### PR DESCRIPTION
It was 'en' before, which seems rather incorrect.